### PR TITLE
Various bug fixes and improvements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,8 +69,8 @@ button#toggleFilter--disabled {
 	all: revert;
 }
 
-/* @media (min-width: 1080px) {
+@media (max-width: 1440px) {
 	.videos {
 		max-width: 60vw;
 	}
-} */
+}

--- a/src/components/SearchButtonContainer.tsx
+++ b/src/components/SearchButtonContainer.tsx
@@ -32,7 +32,7 @@ const SearchButtonContainer: React.FC<props> = ({
 	setFilteredVideos,
 }) => {
 	const [abortController, setAbortController] = React.useState<AbortController>(new AbortController());
-	const [searchingStatus, setSearchingStatus] = React.useState<SearchingStatus>(SearchingStatus.Finished);
+	const [searchingStatus, setSearchingStatus] = React.useState<SearchingStatus>(SearchingStatus.ColdStart);
 
 	const handleGetLikedVideos = () => {
 		console.log("Getting liked videos...");
@@ -74,7 +74,7 @@ const SearchButtonContainer: React.FC<props> = ({
 			case SearchingStatus.Finished:
 				return "Finished Fetching Videos";
 			default:
-				return "";
+				return "Get Liked Videos";
 		}
 	};
 

--- a/src/components/SearchButtonContainer.tsx
+++ b/src/components/SearchButtonContainer.tsx
@@ -37,15 +37,16 @@ const SearchButtonContainer: React.FC<props> = ({
 	const handleGetLikedVideos = () => {
 		console.log("Getting liked videos...");
 		setSearching(true);
-		console.log(abortController);
 		const yt = new YouTubehelper(accessToken);
-		yt.getAllLikedVideosSync({
+		yt.getAllLikedVideos({
 			setLikedVideos,
 			setAmountLoaded,
 			setTotalResults,
 			abortControllerSignal: abortController.signal,
+		}).then((result) => {
+			console.log("Finished fetching all liked videos.");
+			setSearching(false);
 		});
-		// setSearching(false);
 	};
 
 	const handleStopFetchingLikes = () => {

--- a/src/components/SearchButtonContainer.tsx
+++ b/src/components/SearchButtonContainer.tsx
@@ -70,11 +70,10 @@ const SearchButtonContainer: React.FC<props> = ({
 		if (timeout.current) clearTimeout(timeout.current);
 		if (isFiltering) {
 			timeout.current = setTimeout(() => {
-				setFilteredVideos(filterVideos({channelName: filterByChannel, videoTitle: filterByTitle, videos: likedVideos}));
+				setFilteredVideos(
+					filterVideos({ channelName: filterByChannel, videoTitle: filterByTitle, videos: likedVideos })
+				);
 			}, 750);
-		} else {
-			console.log("Clearing filter");
-			setFilteredVideos(likedVideos);
 		}
 	}, [filterByChannel, filterByTitle, isFiltering, likedVideos, setFilteredVideos]);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,6 +84,7 @@ export interface LikedVideoChannel {
 
 // Enums are "objects" in JavaScript, so it will compare the actual values rather than memory addresses
 export enum SearchingStatus {
+	ColdStart,
 	Searching,
 	Paused,
 	Finished,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,3 +81,10 @@ export interface LikedVideoChannel {
 	id: string;
 	name: string;
 }
+
+// Enums are "objects" in JavaScript, so it will compare the actual values rather than memory addresses
+export enum SearchingStatus {
+	Searching,
+	Paused,
+	Finished,
+}

--- a/src/utils/YouTubeHelper.ts
+++ b/src/utils/YouTubeHelper.ts
@@ -60,7 +60,7 @@ export default class YouTubeHelper {
 		};
 	}
 
-	async getAllLikedVideosSync(options: GetAllLikedVideosSync): Promise<{
+	async getAllLikedVideos(options?: GetAllLikedVideosSync): Promise<{
 		videos: LikedVideo[];
 		loadedVideos: number;
 		totalVideos: number;
@@ -73,51 +73,21 @@ export default class YouTubeHelper {
 			try {
 				const { videos, totalVideos, nextPageToken } = await this.getLikedVideos(
 					_nextPageToken,
-					options.abortControllerSignal
+					options?.abortControllerSignal
 				);
+
 				_nextPageToken = nextPageToken;
 				likedVideos = likedVideos.concat(videos);
 				loadedVideos += videos.length;
 				_totalVideos = totalVideos;
-				options.setLikedVideos(likedVideos);
-				options.setAmountLoaded(loadedVideos);
-				options.setTotalResults(totalVideos);
-				await this.sleep(options.delay || 1000);
-			} catch (e) {
-				if (e instanceof Error) {
-					console.log(`Error: ${e.message}`);
+				options?.setLikedVideos(likedVideos);
+				options?.setAmountLoaded(loadedVideos);
+				options?.setTotalResults(totalVideos);
+
+				if (_nextPageToken) {
+					console.log("Sleeping");
+					await this.sleep(options?.delay || 1000);
 				}
-				break;
-			}
-		} while (_nextPageToken);
-
-		return {
-			videos: likedVideos,
-			loadedVideos: loadedVideos,
-			totalVideos: _totalVideos,
-		};
-	}
-
-	async getAllLikedVideos(abortControllerSignal?: AbortSignal): Promise<{
-		videos: LikedVideo[];
-		loadedVideos: number;
-		totalVideos: number;
-	}> {
-		let likedVideos: LikedVideo[] = [];
-		let loadedVideos = 0;
-		let _totalVideos = 0;
-		let _nextPageToken = "";
-		do {
-			try {
-				const { videos, totalVideos, nextPageToken } = await this.getLikedVideos(
-					_nextPageToken,
-					abortControllerSignal
-				);
-				_nextPageToken = nextPageToken;
-				likedVideos = likedVideos.concat(videos);
-				loadedVideos += videos.length;
-				_totalVideos = totalVideos;
-				await this.sleep(5000);
 			} catch (e) {
 				if (e instanceof Error) {
 					console.log(`Error: ${e.message}`);


### PR DESCRIPTION
- Stop unnecessarily resetting `likedVideos` to videos from initial fetch (#5)
---
- Remove previous `getAllLikedVideos`
- Refactor `getAllLikedVideosSync` to `getAllLikedVideos` and make options optional
- Properly handle fetching liked videos and use it asynchronously with a then clause
- Fixes #4 
---
- Refactor searching status to use an enum `SearchingStatus`
- Fixes #3
---
- Update CSS for slightly better scaling on smaller resolution PCs