### PR TITLE
Add footer for privacy policy

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@
 .videos {
 	overflow-y: scroll;
 	max-width: 40vw;
-	max-height: 80vh;
+	max-height: 78vh;
 	/* 	border-radius: 3px;
 	border-color: black;
 	border-style: solid; */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,27 +7,27 @@ function App() {
 	const [accessToken, setAccessToken] = useState<string>("");
 
 	return (
-		<div className={`flex h-screen justify-center ${accessToken ? "text-center items-start py-3" : "items-center"}`}>
-			<div>
-				<h1 className={`font-roboto ${accessToken ? "lg:text-4xl " : "text-2xl lg:text-7xl"}`}>
-					Unlisted YouTube Video Finder
-				</h1>
-				{/* Not sure if this is the proper way to add padding WITHOUT increasing the sizing of the parent div, but it works
-					Other methods I tried did not help and still increased the size such as box-border */}
-				<h3 className={`italic pb-5 ${accessToken ? "" : "text-xs pl-6 -mr-6 lg:text-3xl w-5/6 lg:pl-24 lg:-mr-24"}`}>
-					Find unlisted videos based on the specified filters by parsing your liked videos.
-				</h3>
-				{process.env.REACT_APP_DEV_MODE === "true" && (
-					<>
-						<br />
-						<h3>App Access Token: "{accessToken}"</h3>
-					</>
-				)}
-				{accessToken ? (
-					<Authorized accessToken={accessToken} setAccessToken={setAccessToken} />
-				) : (
-					<Authorize setAccessToken={setAccessToken} />
-				)}
+		<div className="flex flex-col h-screen">
+			<div className={`flex h-screen justify-center overflow-hidden ${accessToken ? "text-center items-start py-3" : "items-center"}`}>
+				<div>
+					<h1 className={`font-roboto ${accessToken ? "lg:text-4xl " : "text-2xl lg:text-7xl"}`}>Unlisted YouTube Video Finder</h1>
+					{/* Not sure if this is the proper way to add padding WITHOUT increasing the sizing of the parent div, but it works
+						Other methods I tried did not help and still increased the size such as box-border */}
+					<h3 className={`italic pb-5 ${accessToken ? "" : "text-xs pl-6 -mr-6 lg:text-3xl w-5/6 lg:pl-24 lg:-mr-24"}`}>
+						Find unlisted videos based on the specified filters by parsing your liked videos.
+					</h3>
+					{process.env.REACT_APP_DEV_MODE === "true" && (
+						<>
+							<br />
+							<h3>App Access Token: "{accessToken}"</h3>
+						</>
+					)}
+					{accessToken ? <Authorized accessToken={accessToken} setAccessToken={setAccessToken} /> : <Authorize setAccessToken={setAccessToken} />}
+				</div>
+			</div>
+			{/* "sticky top-[100vh] text-center" or "mt-auto text-center" */}
+			<div className="mt-auto text-center"> 
+				<a href="https://github.com/Infinitay/Unlisted-YouTube-Video-Finder/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Adds a footer to page that links to the privacy policy that is hosted in this repository.

Continuation for #19 

Also, as a result of the footer, I had to reduce the `max-height` from `80vh` to `78vh` of the video container so that the bottom row of buttons when Authorized would not be clipped.

After adding the footer, before the `max-height` reduction:
![image](https://user-images.githubusercontent.com/6964154/182467223-3af26b69-078d-4ece-9548-5fcc334f3144.png)
