### PR TITLE
Add video privacy status overlay and support for unlisted filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "unlisted-youtube-video-finder",
 	"homepage": "https://infinitay.github.io/Unlisted-YouTube-Video-Finder/",
-	"version": "0.3.2",
+	"version": "0.4.2",
 	"private": true,
 	"dependencies": {
 		"@react-oauth/google": "^0.2.5",

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400&display=swap");
 
 @tailwind base;
 @tailwind components;
@@ -56,12 +56,42 @@
 	cursor: pointer;
 }
 
+.video-result-thumbnail-container {
+	position: relative;
+}
+
 .video-result-thumbnail {
 	/* https://calculateaspectratio.com/16-9-calculator */
 	min-width: 360px;
 	min-height: 203px;
 	width: 360px;
 	height: 203px;
+	/* Corner-cut https://css-generators.com/custom-corners/ */
+	--mask: radial-gradient(2.5rem at 100% 100%, rgba(0, 0, 0, 0) 66%, rgb(0, 0, 0)) 100% 100%/100% 100% no-repeat;
+	-webkit-mask: var(--mask);
+	mask: var(--mask);
+}
+
+.video-result-privacy-status {
+	width: 2rem;
+	height: auto;
+	/* transform: rotate(-45deg); */
+
+	/* Place the image at the bottom right of the corner of the previous element */
+	position: relative;
+	bottom: -2px;
+	right: -4px;
+}
+
+/* Need to do this to fix tool-tip alignment */
+.video-result-privacy-status:after {
+	position: absolute;
+}
+
+.video-result-privacy-status-tooltip {
+	position: absolute;
+	bottom: 0;
+	right: 0;
 }
 
 .video-result-info {
@@ -83,6 +113,23 @@ button#toggleFilter--disabled {
 	all: revert;
 }
 
+.unlisted-button-enabled {
+	color: theme("colors.neutral-content");
+	opacity: 30%;
+	transition-property: color, opacity;
+	transition: 0.25s ease;
+}
+
+.unlisted-button-disabled {
+	transition-property: color, opacity;
+	transition: 0.25s ease;
+}
+
+.unlisted-button-enabled:hover,
+.unlisted-button-disabled:hover {
+	background-color: unset;
+}
+
 @media (max-width: 1440px) {
 	.videos {
 		max-width: 60vw;
@@ -99,10 +146,10 @@ button#toggleFilter--disabled {
 
 @layer base {
 	h1 {
-		@apply text-xl font-roboto
+		@apply text-xl font-roboto;
 	}
 
 	h3 {
-		@apply text-xl font-roboto font-[100]
+		@apply text-xl font-roboto font-[100];
 	}
 }

--- a/src/App.css
+++ b/src/App.css
@@ -114,15 +114,15 @@ button#toggleFilter--disabled {
 }
 
 .unlisted-button-enabled {
-	color: theme("colors.neutral-content");
-	opacity: 30%;
 	transition-property: color, opacity;
-	transition: 0.25s ease;
+	transition: 0.3s ease;
 }
 
 .unlisted-button-disabled {
+	color: theme("colors.neutral-content");
+	opacity: 30%;
 	transition-property: color, opacity;
-	transition: 0.25s ease;
+	transition: 0.3s ease;
 }
 
 .unlisted-button-enabled:hover,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ function App() {
 				</div>
 			</div>
 			{/* "sticky top-[100vh] text-center" or "mt-auto text-center" */}
-			<div className="mt-auto text-center"> 
+			<div className="mt-auto text-center">
 				<a href="https://github.com/Infinitay/Unlisted-YouTube-Video-Finder/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
 			</div>
 		</div>

--- a/src/assets/svgs/README.md
+++ b/src/assets/svgs/README.md
@@ -1,0 +1,1 @@
+These SVGs/JSXs were originally provided by [heroicons](https://heroicons.com/).

--- a/src/assets/svgs/eye-off.svg
+++ b/src/assets/svgs/eye-off.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+	<path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+</svg>

--- a/src/assets/svgs/eye.svg
+++ b/src/assets/svgs/eye.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+	<path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+	<path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+</svg>

--- a/src/components/Authorize.tsx
+++ b/src/components/Authorize.tsx
@@ -12,7 +12,7 @@ const Authorize: React.FC<props> = ({ setAccessToken }) => {
 	return (
 		<div className="text-center" id="authorizeButton">
 			<GoogleOAuthProvider clientId={CLIENT_ID}>
-				<GoogleLoginButton setAccessToken={setAccessToken}/>
+				<GoogleLoginButton setAccessToken={setAccessToken} />
 			</GoogleOAuthProvider>
 		</div>
 	);

--- a/src/components/Authorized.tsx
+++ b/src/components/Authorized.tsx
@@ -21,6 +21,7 @@ const Authorized: React.FC<props> = ({ accessToken, setAccessToken }) => {
 	const [filterByChannel, setFilterByChannel] = React.useState("");
 	const [filterByTitle, setFilterByTitle] = React.useState("");
 	const [isFiltering, setIsFiltering] = React.useState(false);
+	const [showOnlyUnlisted, setShowOnlyUnlisted] = React.useState(false);
 
 	const [likedVideos, setLikedVideos] = React.useState<LikedVideo[]>([]);
 	const [amountLoaded, setAmountLoaded] = React.useState<number>(0);
@@ -46,6 +47,7 @@ const Authorized: React.FC<props> = ({ accessToken, setAccessToken }) => {
 		setFilterByChannel("");
 		setFilterByTitle("");
 		setIsFiltering(false);
+		setShowOnlyUnlisted(false);
 		setSearchingStatus(SearchingStatus.ColdStart);
 	};
 
@@ -64,11 +66,18 @@ const Authorized: React.FC<props> = ({ accessToken, setAccessToken }) => {
 					filterByTitle={filterByTitle}
 					isFiltering={isFiltering}
 					setFilteredVideos={setFilteredVideos}
+					showOnlyUnlisted={showOnlyUnlisted}
 					searchingStatus={searchingStatus}
 					setSearchingStatus={setSearchingStatus}
 				/>
 				{likedVideos.length > 0 && (
-					<Filters setFilterByChannel={setFilterByChannel} setFilterByTitle={setFilterByTitle} setIsFiltering={setIsFiltering} />
+					<Filters
+						setFilterByChannel={setFilterByChannel}
+						setFilterByTitle={setFilterByTitle}
+						setIsFiltering={setIsFiltering}
+						showOnlyUnlisted={showOnlyUnlisted}
+						setShowOnlyUnlisted={setShowOnlyUnlisted}
+					/>
 				)}
 			</div>
 			<ResultContainer
@@ -77,6 +86,7 @@ const Authorized: React.FC<props> = ({ accessToken, setAccessToken }) => {
 				totalResults={totalResults}
 				filteredVideos={filteredVideos}
 				isFiltering={isFiltering}
+				showOnlyUnlisted={showOnlyUnlisted}
 			/>
 			<div className="inline-flex my-3 flex-row space-x-5 items-center justify-evenly">
 				<Button color="secondary" onClick={logout}>

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { Button, Input, Toggle, Tooltip } from "react-daisyui";
 import { ReactComponent as EyeOffIcon } from "../assets/svgs/eye-off.svg";
+
 interface props {
 	setFilterByChannel: React.Dispatch<React.SetStateAction<string>>;
 	setFilterByTitle: React.Dispatch<React.SetStateAction<string>>;
 	setIsFiltering: React.Dispatch<React.SetStateAction<boolean>>;
+	showOnlyUnlisted: boolean;
+	setShowOnlyUnlisted: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Filters: React.FC<props> = ({ setFilterByChannel, setFilterByTitle, setIsFiltering }) => {
-	const [showOnlyUnlisted, setShowOnlyUnlisted] = React.useState(false);
-
+const Filters: React.FC<props> = ({ setFilterByChannel, setFilterByTitle, setIsFiltering, showOnlyUnlisted, setShowOnlyUnlisted }) => {
 	const handleToggleFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setIsFiltering(event.target.checked);
 	};

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Input, Toggle } from "react-daisyui";
-
+import { Button, Input, Toggle, Tooltip } from "react-daisyui";
+import { ReactComponent as EyeOffIcon } from "../assets/svgs/eye-off.svg";
 interface props {
 	setFilterByChannel: React.Dispatch<React.SetStateAction<string>>;
 	setFilterByTitle: React.Dispatch<React.SetStateAction<string>>;
@@ -8,25 +8,26 @@ interface props {
 }
 
 const Filters: React.FC<props> = ({ setFilterByChannel, setFilterByTitle, setIsFiltering }) => {
+	const [showOnlyUnlisted, setShowOnlyUnlisted] = React.useState(false);
+
 	const handleToggleFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
 		setIsFiltering(event.target.checked);
 	};
 
+	const handleToggleShowUnlisted = () => {
+		setShowOnlyUnlisted(!showOnlyUnlisted);
+	};
+
 	return (
 		<div className="flex flex-row space-x-5 items-center justify-evenly">
-			<Input
-				id="channelName"
-				type="text"
-				onChange={(event) => setFilterByChannel(event.target.value)}
-				placeholder="Filter by channel name"
-			/>
-			<Input
-				id="videoTitle"
-				type="text"
-				onChange={(event) => setFilterByTitle(event.target.value)}
-				placeholder="Filter by video title"
-			/>
+			<Input id="channelName" type="text" onChange={(event) => setFilterByChannel(event.target.value)} placeholder="Filter by channel name" />
+			<Input id="videoTitle" type="text" onChange={(event) => setFilterByTitle(event.target.value)} placeholder="Filter by video title" />
 			<Toggle onChange={handleToggleFilter} size="lg" />
+			<Button color="ghost" className={`unlisted-button-${showOnlyUnlisted ? "enabled" : "disabled"}`} onClick={handleToggleShowUnlisted}>
+				<Tooltip message="Show only unlisted videos">
+					<EyeOffIcon />
+				</Tooltip>
+			</Button>
 		</div>
 	);
 };

--- a/src/components/GoogleLoginButton.tsx
+++ b/src/components/GoogleLoginButton.tsx
@@ -28,7 +28,9 @@ const GoogleLoginButton: React.FC<props> = ({ setAccessToken }) => {
 
 	return (
 		<div>
-			<Button color="secondary" onClick={() => login()}>Sign in with Google</Button>
+			<Button color="secondary" onClick={() => login()}>
+				Sign in with Google
+			</Button>
 		</div>
 	);
 };

--- a/src/components/ResultContainer.tsx
+++ b/src/components/ResultContainer.tsx
@@ -1,20 +1,6 @@
 import React from "react";
+import { LikedVideo, PrivacyStatus } from "../types";
 import VideoResult from "./VideoResult";
-
-interface LikedVideo {
-	id: string;
-	title: string;
-	localizedTitle: string;
-	publishedAt: Date;
-	privacyStatus: string; // "public" or "unlisted" or "private", although I don't think "private" is possible
-	thumbnail: string;
-	channel: LikedVideoChannel;
-}
-
-interface LikedVideoChannel {
-	id: string;
-	name: string;
-}
 
 interface props {
 	likedVideos: LikedVideo[];
@@ -22,29 +8,33 @@ interface props {
 	totalResults: number;
 	filteredVideos: LikedVideo[];
 	isFiltering: boolean;
+	showOnlyUnlisted?: boolean;
 }
 
-const ResultsContainer: React.FC<props> = ({
-	likedVideos,
-	amountLoaded,
-	totalResults,
-	filteredVideos,
-	isFiltering,
-}) => {
+const ResultsContainer: React.FC<props> = ({ likedVideos, amountLoaded, totalResults, filteredVideos, isFiltering, showOnlyUnlisted }) => {
+	let resultsString = "";
+	let videosResult: JSX.Element[] = [];
+
+	if (!isFiltering) {
+		resultsString = `Showing ${amountLoaded} of ${totalResults} results`;
+		videosResult = likedVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />);
+	} else if (isFiltering) {
+		resultsString = `Found ${filteredVideos.length} out of ${totalResults} videos that match your filter(s)`;
+		videosResult = filteredVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />);
+	}
+
+	if (showOnlyUnlisted) {
+		resultsString = `Found ${filteredVideos.length} unlisted videos out of ${totalResults} total videos`;
+		videosResult = filteredVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />);
+	} else if (showOnlyUnlisted && isFiltering) {
+		resultsString = `Found ${filteredVideos.length} unlisted videos out of ${totalResults} videos that match your filter(s)`;
+		videosResult = filteredVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />);
+	}
+
 	return (
 		<div className="results-container">
-			{totalResults > 0 && (
-				<div className="mb-3">
-					{!isFiltering
-						? `Showing ${amountLoaded} of ${totalResults} results`
-						: `Found ${filteredVideos.length} out of ${totalResults} videos that match your filter(s)`}
-				</div>
-			)}
-			<div className="videos scrollbar scrollbar-thumb-rounded scrollbar-thumb-base-content scrollbar-track-base-200">
-				{isFiltering
-					? filteredVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />)
-					: likedVideos.map((video) => <VideoResult key={video.id} likedVideo={video} />)}
-			</div>
+			{totalResults > 0 && <div className="mb-3">{resultsString}</div>}
+			<div className="videos scrollbar scrollbar-thumb-rounded scrollbar-thumb-base-content scrollbar-track-base-200">{videosResult}</div>
 		</div>
 	);
 };

--- a/src/components/ResultContainer.tsx
+++ b/src/components/ResultContainer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LikedVideo, PrivacyStatus } from "../types";
+import { LikedVideo } from "../types";
 import VideoResult from "./VideoResult";
 
 interface props {

--- a/src/components/SearchButtonContainer.tsx
+++ b/src/components/SearchButtonContainer.tsx
@@ -3,6 +3,7 @@ import { LikedVideo, SearchingStatus } from "../types";
 import YouTubehelper from "../utils/YouTubeHelper";
 import { filterVideos } from "../utils/FilterHelper";
 import { Button } from "react-daisyui";
+
 interface props {
 	accessToken: string;
 	likedVideos: LikedVideo[];
@@ -15,6 +16,7 @@ interface props {
 	filterByTitle: string;
 	isFiltering: boolean;
 	setFilteredVideos: React.Dispatch<React.SetStateAction<LikedVideo[]>>;
+	showOnlyUnlisted: boolean;
 	searchingStatus: SearchingStatus;
 	setSearchingStatus: React.Dispatch<React.SetStateAction<SearchingStatus>>;
 }
@@ -30,6 +32,7 @@ const SearchButtonContainer: React.FC<props> = ({
 	filterByChannel,
 	filterByTitle,
 	isFiltering,
+	showOnlyUnlisted,
 	setFilteredVideos,
 	searchingStatus,
 	setSearchingStatus,
@@ -92,10 +95,29 @@ const SearchButtonContainer: React.FC<props> = ({
 		if (timeout.current) clearTimeout(timeout.current);
 		if (isFiltering) {
 			timeout.current = setTimeout(() => {
-				setFilteredVideos(filterVideos({ channelName: filterByChannel, videoTitle: filterByTitle, videos: likedVideos }));
+				setFilteredVideos(
+					filterVideos({
+						channelName: filterByChannel,
+						videoTitle: filterByTitle,
+						videos: likedVideos,
+						showOnlyUnlisted: showOnlyUnlisted,
+					})
+				);
 			}, 750);
+		} else {
+			if (showOnlyUnlisted) {
+				console.log("Filtering out listed videos.");
+				setFilteredVideos(
+					filterVideos({
+						videos: likedVideos,
+						showOnlyUnlisted: showOnlyUnlisted,
+					})
+				);
+			} else {
+				setFilteredVideos(likedVideos);
+			}
 		}
-	}, [filterByChannel, filterByTitle, isFiltering, likedVideos, setFilteredVideos]);
+	}, [filterByChannel, filterByTitle, isFiltering, showOnlyUnlisted, likedVideos, setFilteredVideos]);
 
 	useEffect(() => {
 		if (searchingStatus === SearchingStatus.ColdStart) setSearchPageToken("");

--- a/src/components/VideoResult.tsx
+++ b/src/components/VideoResult.tsx
@@ -2,20 +2,7 @@ import React from "react";
 import { ReactComponent as EyeIcon } from "../assets/svgs/eye.svg";
 import { ReactComponent as EyeOffIcon } from "../assets/svgs/eye-off.svg";
 import { Tooltip } from "react-daisyui";
-interface LikedVideo {
-	id: string;
-	title: string;
-	localizedTitle: string;
-	publishedAt: Date;
-	privacyStatus: string; // "public" or "unlisted" or "private", although I don't think "private" is possible
-	thumbnail: string;
-	channel: LikedVideoChannel;
-}
-
-interface LikedVideoChannel {
-	id: string;
-	name: string;
-}
+import { LikedVideo } from "../types";
 
 interface props {
 	likedVideo: LikedVideo;
@@ -44,7 +31,11 @@ const VideoResult: React.FC<props> = ({ likedVideo }) => {
 					alt={likedVideo.title}
 				/>
 				<Tooltip message={likedVideo.privacyStatus} className="video-result-privacy-status-tooltip" position="top">
-					{likedVideo.privacyStatus === "public" ? <EyeIcon className="video-result-privacy-status" /> : <EyeOffIcon className="video-result-privacy-status" />}
+					{likedVideo.privacyStatus === "public" ? (
+						<EyeIcon className="video-result-privacy-status" />
+					) : (
+						<EyeOffIcon className="video-result-privacy-status" />
+					)}
 				</Tooltip>
 			</div>
 			<div className="video-result-info">

--- a/src/components/VideoResult.tsx
+++ b/src/components/VideoResult.tsx
@@ -1,5 +1,7 @@
 import React from "react";
-
+import { ReactComponent as EyeIcon } from "../assets/svgs/eye.svg";
+import { ReactComponent as EyeOffIcon } from "../assets/svgs/eye-off.svg";
+import { Tooltip } from "react-daisyui";
 interface LikedVideo {
 	id: string;
 	title: string;
@@ -34,20 +36,22 @@ const VideoResult: React.FC<props> = ({ likedVideo }) => {
 	};
 	return (
 		<div className="video-result" key={likedVideo.id}>
-			<img
-				className="video-result-thumbnail"
-				onClick={() => openURL(getYouTubeVideoLink(likedVideo.id))}
-				src={likedVideo.thumbnail}
-				alt={likedVideo.title}
-			/>
+			<div className="video-result-thumbnail-container">
+				<img
+					className="video-result-thumbnail"
+					onClick={() => openURL(getYouTubeVideoLink(likedVideo.id))}
+					src={likedVideo.thumbnail}
+					alt={likedVideo.title}
+				/>
+				<Tooltip message={likedVideo.privacyStatus} className="video-result-privacy-status-tooltip" position="top">
+					{likedVideo.privacyStatus === "public" ? <EyeIcon className="video-result-privacy-status" /> : <EyeOffIcon className="video-result-privacy-status" />}
+				</Tooltip>
+			</div>
 			<div className="video-result-info">
 				<div className="video-result-title" onClick={() => openURL(getYouTubeVideoLink(likedVideo.id))}>
 					{likedVideo.title}
 				</div>
-				<div
-					className="video-result-channel"
-					onClick={() => openURL(getYouTubeChannelLink(likedVideo.channel.id))}
-				>
+				<div className="video-result-channel" onClick={() => openURL(getYouTubeChannelLink(likedVideo.channel.id))}>
 					{likedVideo.channel.name}
 				</div>
 			</div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,9 +49,12 @@ export interface Default {
 	height: number;
 }
 
+// https://developers.google.com/youtube/v3/docs/videos#status.privacyStatus
+export type PrivacyStatus = "private" | "public" | "unlisted";
+
 export interface Status {
 	uploadStatus: string;
-	privacyStatus: string;
+	privacyStatus: PrivacyStatus;
 	license: string;
 	embeddable: boolean;
 	publicStatsViewable: boolean;
@@ -72,7 +75,7 @@ export interface LikedVideo {
 	title: string;
 	localizedTitle: string;
 	publishedAt: Date;
-	privacyStatus: string; // "public" or "unlisted" or "private", although I don't think "private" is possible
+	privacyStatus: PrivacyStatus;
 	thumbnail: string;
 	channel: LikedVideoChannel;
 }

--- a/src/utils/FilterHelper.ts
+++ b/src/utils/FilterHelper.ts
@@ -1,30 +1,45 @@
-import { LikedVideo } from "../types";
+import { LikedVideo, PrivacyStatus } from "../types";
 
 interface FilterVideosOptions {
 	channelName?: string;
 	videoTitle?: string;
+	showOnlyUnlisted?: boolean;
 	videos: LikedVideo[];
 }
 
-	export const filterVideos = (options: FilterVideosOptions): LikedVideo[] => {
-		let filteredVideos = filterVideosByChannel(options.channelName || "", options.videos);
-		filteredVideos = filterVideosByTitle(options.videoTitle || "", filteredVideos);
-		return filteredVideos;
-	};
+export const filterVideos = (options: FilterVideosOptions): LikedVideo[] => {
+	let filteredVideos = filterVideosByChannel(options.channelName || "", options.videos);
+	filteredVideos = filterVideosByTitle(options.videoTitle || "", filteredVideos);
 
-	export const filterVideosByTitle = (title: string, videos: LikedVideo[]): LikedVideo[] => {
-		if (!title) return videos;
-		const filtered = videos.filter((video) => video.title.toLowerCase().includes(title.toLowerCase()));
-		console.log(`Found ${filtered.length} videos that match video title of "${title}"`);
-		return filtered;
-	};
+	if (options.showOnlyUnlisted) {
+		filteredVideos = filterVideosByUnlisted(filteredVideos);
+	}
+	return filteredVideos;
+};
 
-	export const filterVideosByChannel = (channel: string, videos: LikedVideo[]): LikedVideo[] => {
-		if (!channel) return videos;
-		const filtered = videos.filter((video) =>
-			video.channel.name.toLowerCase().includes(channel.toLowerCase())
-		);
-		console.log(`Found ${filtered.length} videos that match channel name of "${channel}"`);
-		return filtered;
-	};
+export const filterVideosByTitle = (title: string, videos: LikedVideo[]): LikedVideo[] => {
+	if (!title) return videos;
+	const filtered = videos.filter((video) => video.title.toLowerCase().includes(title.toLowerCase()));
+	console.log(`Found ${filtered.length} videos that match video title of "${title}"`);
+	return filtered;
+};
 
+export const filterVideosByChannel = (channel: string, videos: LikedVideo[]): LikedVideo[] => {
+	if (!channel) return videos;
+	const filtered = videos.filter((video) => video.channel.name.toLowerCase().includes(channel.toLowerCase()));
+	console.log(`Found ${filtered.length} videos that match channel name of "${channel}"`);
+	return filtered;
+};
+
+const filterVideosByPrivacyStatus = (privacyStatus: PrivacyStatus | "", videos: LikedVideo[]): LikedVideo[] => {
+	if (!privacyStatus) return videos;
+	const filtered = videos.filter((video) => video.privacyStatus.toLowerCase().includes(privacyStatus.toLowerCase()));
+	console.log(`Found ${filtered.length} videos that match privacy status of "${privacyStatus}"`);
+	return filtered;
+};
+
+export const filterVideosByUnlisted = (videos: LikedVideo[]): LikedVideo[] => {
+	const filtered = filterVideosByPrivacyStatus("unlisted", videos);
+	console.log(`Found ${filtered.length} videos that are unlisted`);
+	return filtered;
+};


### PR DESCRIPTION
_Note: [YouTube defines](https://developers.google.com/youtube/v3/docs/videos#status.privacyStatus) a video's `privacyStatus` to be one of the following: `private`, `public`, or `unlisted`. Essentially this is the video's visibility as set by the video owner._

## Added a video privacy status overlay

![chrome_9ERVUC5RDs](https://user-images.githubusercontent.com/6964154/182796142-ccacb22c-2a95-4ffe-bf58-197ace0a35a2.gif)

This overlay helps user's know whether or not the video is unlisted. This will be beneficial in the future when video selection and exporting is supported, so that user's can recognize whether or not a video is unlisted.

## Added support for filtering by a video's privacy status

![chrome_9XMEaeiHQ5](https://user-images.githubusercontent.com/6964154/182797021-7ff7628a-4b4d-47e9-8596-8044c6f2144f.gif)

There is now support to quickly filter the list of videos to only display unlisted videos. This will be beneficial in the future when video selection and exporting is supported, so that user's can recognize whether or not a video is unlisted and take actions appropriately. Completes a task in #5. 

## Additional Information
- SVG resources were provided by [heroicons](https://heroicons.com/)
- Refactored existing components to get rid of unnecessary interface declarations
  - These are already declared in types (`src/types/index.ts`)
- Added type `PrivacyStatus` [according to the YouTube's API](https://developers.google.com/youtube/v3/docs/videos#status.privacyStatus) for appropriate `privacyStatus`'
- Refactored codebase to add support for filtering by unlisted videos
  - Added private method for filtering by `PrivacyStatus`
- Formatting/code-style changes